### PR TITLE
GML doesn't allow underscores in attribute names

### DIFF
--- a/src/pyclics_clustering/__init__.py
+++ b/src/pyclics_clustering/__init__.py
@@ -12,12 +12,12 @@ def louvain(graph, kw):
         yield [nodes for nodes in partition.keys() if partition[nodes] == com]
 
 
-def connected_components(graph, kw):
+def connectedcomponents(graph, kw):
     for com in networkx.algorithms.components.connected.connected_components(graph):
         yield list(com)
 
 
-def label_propagation(graph, kw):
+def labelpropagation(graph, kw):
     for com in networkx.algorithms.community.label_propagation.label_propagation_communities(graph):
         yield list(com)
 
@@ -33,5 +33,5 @@ def hlc(graph, kw):
 def includeme(registry):
     registry.register_clusterer(louvain)
     registry.register_clusterer(hlc)
-    registry.register_clusterer(label_propagation)
-    registry.register_clusterer(connected_components)
+    registry.register_clusterer(labelpropagation)
+    registry.register_clusterer(connectedcomponents)


### PR DESCRIPTION
`label_propagation` and `connected_components` clustering methods couldn't be used because GML doesn't allow underscores (ignore the wrong branch name, ha!) in attributes (at least when they are supposed to be written **to** GML, not read **from**).

With underscore:

```
raise NetworkXError('%r is not a valid key' % (key,))
networkx.exception.NetworkXError: 'label_propagation' is not a valid key
```

Without underscore: works!